### PR TITLE
Update Canvas IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ struct AgoraGettingStartedView: View {
         ScrollView {
             VStack {
                 ForEach(Array(agoraManager.allUsers), id: \.self) { uid in
-                    AgoraVideoCanvasView(manager: agoraManager, uid: uid)
+                    AgoraVideoCanvasView(manager: agoraManager, canvasId: .userId(uid))
                         .aspectRatio(contentMode: .fit).cornerRadius(10)
                 }
             }.padding(20)

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ struct AgoraGettingStartedView: View {
                 }
             }.padding(20)
         }.onAppear {
-            agoraManager.engine.joinChannel(
+            agoraManager.agoraEngine.joinChannel(
                 byToken: <#Agora Temp Token#>, channelId: channelId, info: nil, uid: 0
             )
         }.onDisappear {
-            agoraManager.engine.leaveChannel()
+            agoraManager.agoraEngine.leaveChannel()
         }
     }
 }

--- a/Sources/SwiftUIRtc/AgoraVideoCanvasView.swift
+++ b/Sources/SwiftUIRtc/AgoraVideoCanvasView.swift
@@ -62,9 +62,10 @@ public struct AgoraVideoCanvasView: ViewRepresentable {
 
     /// 🆔 An enum representing different types of canvas IDs, indicating whether it represents a user ID or a media source.
     public enum CanvasIdType {
-        /// 🆔 Represents a user ID for the video stream.
+        /// 🆔 Represents a user ID for the video stream. You'll use this for joining most channels.
         case userId(UInt)
         /// 🆔 Represents a user ID with an `AgoraRtcConnection` for the video stream.
+        /// Used when you've joined a channel with `joinChannelEx`.
         case userIdEx(UInt, AgoraRtcConnection)
         /// 🆔 Represents a media source with an `AgoraVideoSourceType` and an optional media player ID.
         case mediaSource(AgoraVideoSourceType, mediaPlayerId: Int32?)
@@ -103,28 +104,51 @@ public struct AgoraVideoCanvasView: ViewRepresentable {
     /// Properties struct to encapsulate all possible canvas properties
     public struct CanvasProperties {
         /// 🎨 The render mode for the video stream, which determines how the video is scaled and displayed.
-        var renderMode: AgoraVideoRenderMode = .hidden
+        public var renderMode: AgoraVideoRenderMode
         /// 🖼️ The portion of the video stream to display, specified as a CGRect with values between 0 and 1.
-        var cropArea: CGRect = .zero
+        public var cropArea: CGRect
         /// 🔧 The mode for setting up the video view, which determines whether to replace or merge with existing views.
-        var setupMode: AgoraVideoViewSetupMode = .replace
-        /// 🔄 The mirror mode for the video stream.
-        var mirrorMode: AgoraVideoMirrorMode = .disabled
-        /// 🔤 Enables or disables the alpha mask for the video stream.
-        var enableAlphaMask: Bool = false
+        public var setupMode: AgoraVideoViewSetupMode
+        /// 🪞 A property that represents the mirror mode for the video stream.
+        /// The mirror mode determines how the video is mirrored when displayed.
+        public var mirrorMode: AgoraVideoMirrorMode
+        /// 🫥 A property that determines whether the alpha mask is enabled for the video stream.
+        /// When `true`, the alpha mask is enabled, allowing transparency to be displayed in the video stream.
+        /// When `false`, the alpha mask is disabled, and the video stream is opaque.
+        public var enableAlphaMask: Bool
+
+        /// Initializes a `CanvasProperties` instance with the specified values.
+        ///
+        /// - Parameters:
+        ///   - renderMode: 🎨 The render mode for the video stream, which determines how the video is scaled and displayed.
+        ///   - cropArea: 🖼️ The portion of the video stream to display, specified as a CGRect with values between 0 and 1.
+        ///   - setupMode: 🔧 The mode for setting up the video view, which determines whether to replace or merge with existing views.
+        ///   - mirrorMode: 🪞 A property that represents the mirror mode for the video stream.
+        ///   - enableAlphaMask: 🫥 Enables or disables the alpha mask for the video stream.
+        public init(renderMode: AgoraVideoRenderMode = .hidden,
+                    cropArea: CGRect = .zero,
+                    setupMode: AgoraVideoViewSetupMode = .replace,
+                    mirrorMode: AgoraVideoMirrorMode = .disabled,
+                    enableAlphaMask: Bool = false) {
+            self.renderMode = renderMode
+            self.cropArea = cropArea
+            self.setupMode = setupMode
+            self.mirrorMode = mirrorMode
+            self.enableAlphaMask = enableAlphaMask
+        }
     }
 
     /// 🔤 The canvas properties struct to encapsulate all possible canvas properties.
     private var canvasProperties: CanvasProperties
-    /// 🎨 The render mode for the view.
+    /// 🎨 The render mode for the video stream, which determines how the video is scaled and displayed.
     public var renderMode: AgoraVideoRenderMode {
         get { canvasProperties.renderMode } set { canvasProperties.renderMode = newValue }
     }
-    /// 🖼️ The crop area for the view.
+    /// 🖼️ The portion of the video stream to display, specified as a CGRect with values between 0 and 1.
     public var cropArea: CGRect {
         get { canvasProperties.cropArea } set { canvasProperties.cropArea = newValue }
     }
-    /// 🔧 The setup mode for the view.
+    /// 🔧 The mode for setting up the video view, which determines whether to replace or merge with existing views.
     public var setupMode: AgoraVideoViewSetupMode {
         get { canvasProperties.setupMode } set { canvasProperties.setupMode = newValue }
     }
@@ -175,11 +199,11 @@ public struct AgoraVideoCanvasView: ViewRepresentable {
     public init(
         manager: CanvasViewHelper,
         canvasId: CanvasIdType,
-        canvasProps: CanvasProperties? = nil
+        canvasProps: CanvasProperties = CanvasProperties()
     ) {
         self.manager = manager
         self.canvasId = canvasId
-        self.canvasProperties = canvasProps ?? CanvasProperties()
+        self.canvasProperties = canvasProps
     }
 
     // MARK: - Setup

--- a/Sources/SwiftUIRtc/SwiftUIRtc.docc/SwiftUI-Video-Streaming.md
+++ b/Sources/SwiftUIRtc/SwiftUIRtc.docc/SwiftUI-Video-Streaming.md
@@ -51,7 +51,7 @@ struct ScrollingVideoCallView: View {
         ScrollView {
             VStack {
                 ForEach(Array(agoraManager.allUsers), id: \.self) { uid in
-                    AgoraVideoCanvasView(manager: agoraManager, uid: uid)
+                    AgoraVideoCanvasView(manager: agoraManager, canvasId: .userId(uid))
                         .aspectRatio(contentMode: .fit).cornerRadius(10)
                 }
             }.padding(20)
@@ -110,7 +110,7 @@ extension CallQualityManager {
 To display those call quality data, a simple change to ScrollingVideoCallView (above) adds an overlay to each ``AgoraVideoCanvasView``:
 
 ```swift
-AgoraVideoCanvasView(manager: agoraManager, uid: uid)
+AgoraVideoCanvasView(manager: agoraManager, canvasId: .userId(uid))
     .aspectRatio(contentMode: .fit).cornerRadius(10)
     .overlay(alignment: .topLeading) {
         Text(agoraManager.callQualities[uid] ?? "no data").padding()

--- a/Sources/SwiftUIRtc/SwiftUIRtc.docc/SwiftUIRtc.md
+++ b/Sources/SwiftUIRtc/SwiftUIRtc.docc/SwiftUIRtc.md
@@ -19,7 +19,7 @@ struct AgoraGettingStartedView: View {
     var body: some View {
         ScrollView { VStack {
             ForEach(Array(agoraManager.allUsers), id: \.self) { uid in
-                AgoraVideoCanvasView(manager: agoraManager, uid: uid)
+                AgoraVideoCanvasView(manager: agoraManager, canvasId: .userId(uid))
                     .aspectRatio(contentMode: .fit).cornerRadius(10)
             }
         }.padding(20) }


### PR DESCRIPTION
Sometimes a regular user ID won't cut it for showing local or remote streams.

In situations where you join a channel with `joinChannelEx`, or when streaming local media like a video file.

We now have an enum `CanvasIdType` with three types available to apply to canvases:

```swift
/// 🆔 An enum representing different types of canvas IDs, indicating whether it represents a user ID or a media source.
public enum CanvasIdType {
    /// 🆔 Represents a user ID for the video stream. You'll use this for joining most channels.
    case userId(UInt)
    /// 🆔 Represents a user ID with an `AgoraRtcConnection` for the video stream.
    /// Used when you've joined a channel with `joinChannelEx`.
    case userIdEx(UInt, AgoraRtcConnection)
    /// 🆔 Represents a media source with an `AgoraVideoSourceType` and an optional media player ID.
    case mediaSource(AgoraVideoSourceType, mediaPlayerId: Int32?)
}
```