### PR TITLE
Black Screen Swap UID Fix

### DIFF
--- a/Sources/SwiftUIRtc/AgoraVideoCanvasView.swift
+++ b/Sources/SwiftUIRtc/AgoraVideoCanvasView.swift
@@ -251,6 +251,9 @@ public struct AgoraVideoCanvasView: ViewRepresentable {
         if canvas.setupMode != setupMode { canvas.setupMode = setupMode }
         if canvas.mirrorMode != mirrorMode { canvas.mirrorMode = mirrorMode }
         if canvas.enableAlphaMask != enableAlphaMask { canvas.enableAlphaMask = enableAlphaMask }
+        if let manager {
+            self.setUserId(to: self.canvasId, agoraEngine: manager.agoraEngine)
+        }
     }
 
     /// Updates the Canvas view.


### PR DESCRIPTION
Fixed this scenario with a featured image, the views would break after one view replaces another:

```swift
struct ContentView: View {
    @ObservedObject var agoraManager = AgoraManager(appId: "<#Agora App ID#>", role: .broadcaster)
    var body: some View {
        let users = Array(agoraManager.allUsers)
        VStack {
            if let fst = users.first {
                AgoraVideoCanvasView(manager: agoraManager, canvasId: .userId(fst))
                    .aspectRatio(contentMode: .fit).cornerRadius(10)
            }
            ScrollView {
                HStack {
                    ForEach(users.dropFirst(), id: \.self) { uid in
                        AgoraVideoCanvasView(manager: agoraManager, canvasId: .userId(uid))
                            .aspectRatio(contentMode: .fit).cornerRadius(10)
                    }

                }
            }
        }.onAppear { agoraManager.joinChannel("example") }
    }
}
```